### PR TITLE
Updated Popup show() and hide() mechanism.

### DIFF
--- a/dist/frappe-gantt.js
+++ b/dist/frappe-gantt.js
@@ -1021,11 +1021,11 @@ class Popup {
         }
 
         // show
-        this.parent.style.opacity = 1;
+        this.parent.style.display = 'block';
     }
 
     hide() {
-        this.parent.style.opacity = 0;
+        this.parent.style.display = 'none';
     }
 }
 


### PR DESCRIPTION
## Proposed a change to the popup show and hide mechanism

Hiding a popup by setting the opacity to 0 made the bars unclickable that was under the popup. By setting the display attribute to "none" fixes the issue.